### PR TITLE
Fixing Issue #41

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mappoly
 Type: Package
 Title: Genetic Linkage Maps in Autopolyploids
-Version: 0.2.3
+Version: 0.2.3.001
 Authors@R: c(person(given = "Marcelo",
                     family = "Mollinari",
                     role = c("aut", "cre"),

--- a/R/read_mappoly_csv.R
+++ b/R/read_mappoly_csv.R
@@ -66,7 +66,7 @@
 #' print(SolCAP.dose, detailed = TRUE)
 #' plot(SolCAP.dose)
 #'}
-#' @author Marcelo Mollinari, \email{mmollin@ncsu.edu}
+#' @author Marcelo Mollinari, \email{mmollin@ncsu.edu}, with minor changes by Gabriel Gesteira, \email{gabrielgesteira@usp.br}
 #'
 #' @references
 #' 
@@ -88,6 +88,8 @@
 read_geno_csv <- function(file.in, ploidy, filter.non.conforming = TRUE, elim.redundant = TRUE, verbose = TRUE) {
   m <- ploidy
   dat<-read.csv(file = file.in, header = TRUE, stringsAsFactors = FALSE)
+  ## Removing markers with missing datapoints for parents
+  dat = dat[which(!is.na(dat$P1) & !is.na(dat$P2)),]
   ## get number of individuals -------------
   n.ind <- ncol(dat) - 5
   ## get number of markers -----------------

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ![](https://raw.githubusercontent.com/mmollina/MAPpoly/master/mappoly_hexsticker.png)
 
-MAPpoly (v. 0.2.1) is an R package to construct genetic maps in autopolyploids with even ploidy levels. In its current version, MAPpoly can handle ploidy levels up to 8 when using hidden Markov models (HMM), and up to 12 when using the two-point simplification. When dealing with large numbers of markers (> 10,000), we strongly recommend using high-performance computation. 
+MAPpoly (v. 0.2.3) is an R package to construct genetic maps in autopolyploids with even ploidy levels. In its current version, MAPpoly can handle ploidy levels up to 8 when using hidden Markov models (HMM), and up to 12 when using the two-point simplification. When dealing with large numbers of markers (> 10,000), we strongly recommend using high-performance computation. 
 
 ![](https://raw.githubusercontent.com/mmollina/MAPpoly/master/mappoly.gif)
 


### PR DESCRIPTION
Fixing `read_geno_csv` to filter parental missing data (mmollina/MAPpoly#41).