### PR TITLE
Fix linking to RcppParallel

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,1 @@
+PKG_LIBS = $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::RcppParallelLibs()")


### PR DESCRIPTION
Properly link to RcppParallel. This will fix the error with cross compiling: https://github.com/r-universe/mmollina/actions/runs/7504604767/job/20432372283

Here some examples from other CRAN packages: https://github.com/search?q=org%3Acran%20path%3Asrc%2FMakevars%20RcppParallelLibs&type=code